### PR TITLE
Updating gruntfile.js to properly compile the scss

### DIFF
--- a/slide-foundation/Gruntfile.js
+++ b/slide-foundation/Gruntfile.js
@@ -8,8 +8,11 @@ module.exports = function(grunt) {
 		pkg: grunt.file.readJSON('package.json'),
 
 		sass: {
-			src: 'css/source/open-drupal.scss',
-			dest: 'css/open-drupal.css'
+			dist: {
+				files: {
+						'css/open-drupal.css': 'css/source/open-drupal.scss'
+				}
+			}
 		},
 
 		watch: {


### PR DESCRIPTION
I've changed the gruntfile.js settings to compile the scss in /css/source to /css properly.
I had issues getting gulp to compile this before. Running `gulp watch` in /slide-foundation works properly with this change.